### PR TITLE
"Reset all" button now works correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * "View log" button text is now "Current" or "Last" depending on status; "Old jobs" button added to harvestables list. Fixes UIHAADM-54.
 * Politer error reporting. Fixes UIHAADM-56.
 * Do not append asterisks to query terms. Fixes UIHAADM-58.
+* "Reset all" button now correctly causes query-index and filters to redisplay as unselected. Fixes UIHAADM-59.
 
 ## [0.1.0](https://github.com/folio-org/ui-harvester-admin/tree/v0.1.0) (2022-07-19)
 

--- a/src/search/HarvestablesSearchPane.js
+++ b/src/search/HarvestablesSearchPane.js
@@ -78,7 +78,7 @@ function HarvestablesSearchPane(props) {
             buttonStyle="none"
             id="clickable-reset-all"
             disabled={false}
-            onClick={() => updateQuery({ qindex: undefined, query: undefined, sort: undefined, filters: undefined })}
+            onClick={() => updateQuery({ qindex: '', query: undefined, sort: undefined, filters: undefined })}
           >
             <Icon icon="times-circle-solid">
               <FormattedMessage id="stripes-smart-components.resetAll" />

--- a/src/search/JobsSearchPane.js
+++ b/src/search/JobsSearchPane.js
@@ -80,7 +80,7 @@ function JobsSearchPane(props) {
             buttonStyle="none"
             id="clickable-reset-all"
             disabled={false}
-            onClick={() => updateQuery({ qindex: undefined, query: undefined, sort: undefined, filters: undefined })}
+            onClick={() => updateQuery({ qindex: '', query: undefined, sort: undefined, filters: undefined })}
           >
             <Icon icon="times-circle-solid">
               <FormattedMessage id="stripes-smart-components.resetAll" />

--- a/src/search/RecordsSearchPane.js
+++ b/src/search/RecordsSearchPane.js
@@ -88,7 +88,7 @@ function RecordsSearchPane(props) {
             buttonStyle="none"
             id="clickable-reset-all"
             disabled={false}
-            onClick={() => updateQuery({ qindex: undefined, query: undefined, sort: undefined, filters: undefined })}
+            onClick={() => updateQuery({ qindex: '', query: undefined, sort: undefined, filters: undefined })}
           >
             <Icon icon="times-circle-solid">
               <FormattedMessage id="stripes-smart-components.resetAll" />

--- a/src/search/renderFilter.js
+++ b/src/search/renderFilter.js
@@ -27,7 +27,7 @@ function renderFilter(intl, filterStruct, updateQuery, qualifiedField, optionTag
         name={`multifilter-${field}`}
         label={intl.formatMessage({ id: `ui-harvester-admin.${transTag}` })}
         dataOptions={dataOptions}
-        selectedValues={filterStruct[field]}
+        selectedValues={filterStruct[field] || []}
         onChange={(group) => {
           const fs2 = { ...filterStruct, [field]: group.values };
           updateQuery({ filters: deparseFilters(fs2) });
@@ -43,7 +43,7 @@ function renderFilter(intl, filterStruct, updateQuery, qualifiedField, optionTag
         { value: NO_VALUE, label: intl.formatMessage({ id: 'ui-harvester-admin.no-value' }) },
         ...dataOptions
       ]}
-      value={filterStruct[field] && filterStruct[field][0]}
+      value={filterStruct[field] ? filterStruct[field][0] : ''}
       onChange={(e) => {
         const val = e.target.value;
         const fs2 = { ...filterStruct };


### PR DESCRIPTION
It correctly causes the query-index and filters to redisplay as unselected, as well as setting them empty in the URL query (as it did before).

Fixes UIHAADM-59.
