### PR TITLE
Failed Records view's "Record number" column can no longer be hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-harvester-admin
 
+## (IN PROGRESS)
+
+* In the Failed Records view, the "Record number" column can no longer be hidden. Fixes UIHAADM-71.
+
 ## [1.0.3](https://github.com/folio-org/ui-harvester-admin/tree/v1.0.3) (2023-05-26)
 
 * Error-summarising function tolerates more possible structures. Fixes UIHAADM-72.

--- a/src/views/Records/Records.js
+++ b/src/views/Records/Records.js
@@ -69,7 +69,7 @@ function Records({
                   <ColumnManager
                     id="records-visible-columns"
                     columnMapping={columnMapping}
-                    excludeKeys={['name']}
+                    excludeKeys={['recordNumber']}
                     persist
                   >
                     {({ renderColumnsMenu, visibleColumns }) => (


### PR DESCRIPTION
Fixes UIHAADM-71.