### PR TITLE
UIHAADM-69: Improve DatePicker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Sort jobs in descending order by start date. Fixes UIHAADM-94.
 * Paginate list of jobs. Fixes UIHAADM-95.
+* Improve DatePicker setup. Fixes UIHAADM-69.
 
 ## [2.0.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.0.0) (2023-10-13)
 

--- a/src/search/renderDateFilterPair.js
+++ b/src/search/renderDateFilterPair.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { omit } from 'lodash';
 import { Accordion, FilterAccordionHeader, Datepicker } from '@folio/stripes/components';
 import { deparseFilters } from '@folio/stripes/smart-components';
 
@@ -14,17 +15,14 @@ function renderSingleDateFilter(intl, filterStruct, updateQuery, field, boundary
   return (
     <Datepicker
       label={intl.formatMessage({ id: `ui-harvester-admin.filter.date.${field}.${boundary}` })}
+      backendDateStandard="YYYY-MM-DD"
       value={value}
       onChange={(e) => {
         const isoDateTime = e.target.value;
-        if (isoDateTime === '') {
-          // This can happen when navigating away to Settings then hitting the back button.
-          // I have no idea why doing so activates the click-handler, but it does.
-          // In this case, we will not break the query string by setting the empty value into it.
-          return;
-        }
-        const isoDate = isoDateTime.substring(0, 10);
-        const fs2 = { ...filterStruct, [keyString]: [isoDate] };
+        const fs2 = (!isoDateTime) ?
+          omit(filterStruct, keyString) :
+          { ...filterStruct, [keyString]: [e.target.value] };
+
         updateQuery({ filters: deparseFilters(fs2) });
       }}
       useInput

--- a/src/views/Jobs/Jobs.js
+++ b/src/views/Jobs/Jobs.js
@@ -79,7 +79,7 @@ function Jobs({
             <Paneset id="jobs-paneset">
               <JobsSearchPane
                 {...sasqParams}
-                defaultWidth="20%"
+                defaultWidth="25%"
                 query={query}
                 updateQuery={updateQuery}
               />


### PR DESCRIPTION
This PR addresses two issues:

1. It correctly handles date conversion. By adding the `backendDateStandard` prop, the correct conversion should occur while working from a different locale. This should address the issue of the date being off by a day.
2. It correctly clears the filter in the URL when the clear icon is clicked within the date picker field.
