### PR TITLE
UIHAADM-98: Display Datepicker in full view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Sort jobs in descending order by start date. Fixes UIHAADM-94.
 * Paginate list of jobs. Fixes UIHAADM-95.
 * Improve DatePicker setup. Fixes UIHAADM-69.
+* Display Datepicker in full view. Fixes UIHAADM-98.
 
 ## [2.0.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.0.0) (2023-10-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Sort jobs in descending order by start date. Fixes UIHAADM-94.
 * Paginate list of jobs. Fixes UIHAADM-95.
 * Improve DatePicker setup. Fixes UIHAADM-69.
-* Display Datepicker in full view. Fixes UIHAADM-98.
+* Display `<Datepicker>` in full view by using `usePortal`. Fixes UIHAADM-98.
 
 ## [2.0.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.0.0) (2023-10-13)
 

--- a/src/search/renderDateFilterPair.js
+++ b/src/search/renderDateFilterPair.js
@@ -26,6 +26,8 @@ function renderSingleDateFilter(intl, filterStruct, updateQuery, field, boundary
         updateQuery({ filters: deparseFilters(fs2) });
       }}
       useInput
+      usePortal
+      placement="right"
     />
   );
 }

--- a/src/views/Jobs/Jobs.js
+++ b/src/views/Jobs/Jobs.js
@@ -79,7 +79,7 @@ function Jobs({
             <Paneset id="jobs-paneset">
               <JobsSearchPane
                 {...sasqParams}
-                defaultWidth="25%"
+                defaultWidth="20%"
                 query={query}
                 updateQuery={updateQuery}
               />


### PR DESCRIPTION
https://issues.folio.org/browse/UIHAADM-98

Display Datepicker in full view by using `usePortal` prop.


![datepicker](https://github.com/indexdata/ui-harvester-admin/assets/63545/0ae09637-2c1e-40db-9d25-c4580d0b7d9b)
