### PR TITLE
Full display of a job now includes start time in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Paginate list of jobs. Fixes UIHAADM-95.
 * Improve DatePicker setup. Fixes UIHAADM-69.
 * Display `<Datepicker>` in full view by using `usePortal`. Fixes UIHAADM-98.
+* Full display of a job now includes start time in header instead of current time. Fixes UIHAADM-103.
 
 ## [2.0.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.0.0) (2023-10-13)
 

--- a/src/util/message2stats.js
+++ b/src/util/message2stats.js
@@ -9,7 +9,7 @@ function message2stats(message) {
       const [_matched, name, processed, loaded, deleted, failed] = matchData;
       stats[name.toLowerCase()] = { processed, loaded, deleted, failed };
     } else {
-      // eslint-disable-next-line no-console
+      // eslint-disable-next-line no-console, no-lonely-if
       if (row) console.warn('message2stats: no match for row:', row);
     }
   });

--- a/src/views/HarvestableLog/HarvestableLog.js
+++ b/src/views/HarvestableLog/HarvestableLog.js
@@ -41,7 +41,8 @@ const HarvestableLog = (props) => {
   const paneTitle = (
     <>
       {record.name}
-      ({formatDateTime(record.lastHarvestFinished)})
+      &nbsp;
+      ({formatDateTime(record.started)})
       {status &&
         <>
           {' '}&mdash;{' '}
@@ -79,7 +80,7 @@ HarvestableLog.propTypes = {
   data: PropTypes.shape({
     record: PropTypes.shape({
       name: PropTypes.string.isRequired,
-      lastHarvestFinished: PropTypes.string,
+      started: PropTypes.string,
       currentStatus: PropTypes.string, // .isRequired for harvestable, not for previous-job
     }),
     plainTextLog: PropTypes.string,


### PR DESCRIPTION
Instead of current time, as was incorrectly shown before.

Fixes UIHAADM-103.