### PR TITLE
Step deletion failures are politely reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve DatePicker setup. Fixes UIHAADM-69.
 * Display `<Datepicker>` in full view by using `usePortal`. Fixes UIHAADM-98.
 * Full display of a job now includes start time in header instead of current time. Fixes UIHAADM-103.
+* When trying to delete an in-use step, this is rejected with a polite error message. Fixes last part of UIHAADM-9.
 
 ## [2.0.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.0.0) (2023-10-13)
 

--- a/src/smart-components/lib/EntryManager/EntryWrapper.js
+++ b/src/smart-components/lib/EntryManager/EntryWrapper.js
@@ -121,7 +121,7 @@ export default class EntryWrapper extends React.Component {
     return this.props.parentMutator[rk].DELETE(entry).then(() => {
       this.showCalloutMessage(entry[this.props.nameKey]);
       this.hideLayer();
-    });
+    }).catch(this.handleSaveError);
   }
 
   onSave(entry) {


### PR DESCRIPTION
When trying to delete an in-use step, this is rejected with a polite error message.

I did this by adding a `catch` clause to our fork of `<EntryWrapper>`. Some day, I should probably make some kind of effort to merge this back into stripes-smart-components.

Fixes last part of UIHAADM-9.