### PR TITLE
DEVOPS-2662 Use Action Srxzwei/github-action-json-property

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get version from package.json
         id: package_version
         # uses: notiz-dev/github-action-json-property@release
-        uses: Srxzwei/github-action-json-property@v1
+        uses: Srxzwei/github-action-json-property@v1.0.0
         with:
           path: 'package.json'
           prop_path: 'version'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get version from package.json
         id: package_version
         # uses: notiz-dev/github-action-json-property@release
-        uses: Srxzwei/github-action-json-property@v1.0.0
+        uses: Srxzwei/github-action-json-property@1.0.0
         with:
           path: 'package.json'
           prop_path: 'version'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -22,7 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Get version from package.json
         id: package_version
-        uses: notiz-dev/github-action-json-property@release
+        # uses: notiz-dev/github-action-json-property@release
+        uses: Srxzwei/github-action-json-property@v1
         with:
           path: 'package.json'
           prop_path: 'version'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get version from package.json
         id: package_version
         # uses: notiz-dev/github-action-json-property@release
-        uses: Srxzwei/github-action-json-property@v1
+        uses: Srxzwei/github-action-json-property@v1.0.0
         with:
           path: 'package.json'
           prop_path: 'version'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -32,7 +32,8 @@ jobs:
         run: echo "TAG_VERSION=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
       - name: Get version from package.json
         id: package_version
-        uses: notiz-dev/github-action-json-property@release
+        # uses: notiz-dev/github-action-json-property@release
+        uses: Srxzwei/github-action-json-property@v1
         with:
           path: 'package.json'
           prop_path: 'version'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get version from package.json
         id: package_version
         # uses: notiz-dev/github-action-json-property@release
-        uses: Srxzwei/github-action-json-property@v1.0.0
+        uses: Srxzwei/github-action-json-property@1.0.0
         with:
           path: 'package.json'
           prop_path: 'version'


### PR DESCRIPTION
The original Action notiz-dev/github-action-json-property is not being attended, and it still uses Node16.

So replacing with one of the forks, which does use Node20.

As with the original, note the lack of leading v for the version identifier.