### PR TITLE
Failed-record errors from "message" instead of "label"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+junit.xml
 node_modules
 yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-harvester-admin
 
+## 2.2.0 (IN PROGRESS)
+
+* Failed-record error messages should use detailed "message", when present, instead of label. Fixes UIHAADM-125.
+
 ## [2.1.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.1.0) (2024-02-28)
 
 * Sort jobs in descending order by start date. Fixes UIHAADM-94.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@folio/jest-config-stripes');

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "stripes serve --port 3003 --okapi https://harvester-dev-okapi.folio-dev.indexdata.com --tenant harvester",
+    "test": "jest",
     "minerva3": "stripes serve --port 3004 --okapi https://okapi.gbv.de --tenant minerva3",
     "lint": "eslint -f unix .",
     "qlint": "eslint -f unix  --rule '{\"no-console\":\"off\"}' .",

--- a/src/util/summarizeErrors.js
+++ b/src/util/summarizeErrors.js
@@ -8,7 +8,7 @@ function errors2react(errors) {
         errors.map(error => {
           const message = error.error?.message;
           const errorList = message?.errors;
-          const mm = message.message;
+          const mm = message?.message;
 
           if (errorList) {
             return errorList.map((x, i) => <li key={i}>{x.message}</li>);
@@ -30,7 +30,7 @@ function errors2string(errors) {
     errors.map(error => {
       const message = error.error?.message;
       const errorList = message?.errors;
-      const mm = message.message;
+      const mm = message?.message;
 
       if (errorList) {
         return errorList.map(x => x.message).join(' / ');

--- a/src/util/summarizeErrors.js
+++ b/src/util/summarizeErrors.js
@@ -14,6 +14,8 @@ function errors2react(errors) {
             return errorList.map((x, i) => <li key={i}>{x.message}</li>);
           } else if (mm) {
             return mm;
+          } else if (error.error?.message) {
+            return error.error?.message;
           } else {
             return error.error?.label;
           }
@@ -34,6 +36,8 @@ function errors2string(errors) {
         return errorList.map(x => x.message).join(' / ');
       } else if (mm) {
         return mm;
+      } else if (error.error?.message) {
+        return error.error?.message;
       } else {
         return error.error?.label;
       }

--- a/src/util/summarizeErrors.test.js
+++ b/src/util/summarizeErrors.test.js
@@ -1,101 +1,29 @@
 import { errors2string } from './summarizeErrors';
 
-const errorsString = `[
+const errorFromMessage = `[
   {
     "error": {
       "label": "Error encountered during upsert of Inventory record set",
-      "entity": {
-        "id": "c352fe11-51e2-4e8b-87d6-578d6dedec8b",
-        "hrid": "1877906867",
-        "notes": [
-          {
-            "note": "Dissertation, Universität Bremen, 2023",
-            "instanceNoteTypeId": "b73cc9c2-c9fa-49aa-964f-5ae1aa754ecd"
-          }
-        ],
-        "title": "Antje test alter titel mit 3 Exemplaren. 19F-MR basierte Temperaturbestimmung in biokompatiblen Lösungen unter Einsatz neuer fluorierter Ligandensysteme und ausgewählter Übergangsmetallkomplexe / Felix Mysegaes",
-        "series": [
-          {
-            "value": "Medizinische Chemie"
-          }
-        ],
-        "source": "K10plus",
-        "_version": 1,
-        "editions": [
-          "1. Auflage"
-        ],
-        "languages": [
-          "ger"
-        ],
-        "indexTitle": "Antje test alter titel mit 3 Exemplaren 19FMR basierte Temperaturbestimmung in biokompatiblen Lösungen unter Einsatz neuer fluorierter Ligandensysteme und ausgewählter Übergangsmetallkomplexe Felix Mysegaes",
-        "identifiers": [
-          {
-            "value": "1877906867",
-            "identifierTypeId": "1d5cb40c-508f-451b-8952-87c92be4255a"
-          },
-          {
-            "value": "9783843954136",
-            "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
-          },
-          {
-            "value": "KXP: 1877906867",
-            "identifierTypeId": "8e33c1be-e2c4-43ac-a975-8fb50f71137a"
-          }
-        ],
-        "publication": [
-          {
-            "role": "Publisher",
-            "place": "München",
-            "publisher": "Verlag Dr. Hut",
-            "dateOfPublication": "2024"
-          }
-        ],
-        "contributors": [
-          {
-            "name": "Mysegaes, Felix",
-            "primary": "true",
-            "contributorTypeId": "6e09d47d-95e2-4d8a-831b-f777b8ef6d81",
-            "contributorTypeText": "VerfasserIn",
-            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
-          },
-          {
-            "name": "Montforts, F.-P.",
-            "contributorTypeId": "825a7d9f-7596-4007-9684-9bee72625cfc",
-            "contributorTypeText": "AkademischeR BetreuerIn",
-            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
-          },
-          {
-            "name": "Plaumann, M.",
-            "contributorTypeId": "825a7d9f-7596-4007-9684-9bee72625cfc",
-            "contributorTypeText": "AkademischeR BetreuerIn",
-            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
-          }
-        ],
-        "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
-        "electronicAccess": [],
-        "modeOfIssuanceId": "9d18a02f-5897-4c31-9106-c9abb5c7ae8b",
-        "alternativeTitles": [],
-        "instanceFormatIds": [
-          "8d511d33-5e85-4c5d-9bce-6e3c9cd0c324"
-        ],
-        "administrativeNotes": [
-          "Aau (0500: Bibliografische Gattung)",
-          "14.01.24, 19:02 (0210: Datum der letzten Änderung)"
-        ],
-        "natureOfContentTermIds": [
-          "94f6d06a-61e0-47c1-bbcb-6186989e6040"
-        ]
-      },
-      "message": "ERROR: Cannot update record c352fe11-51e2-4e8b-87d6-578d6dedec8b because it has been changed (optimistic locking): Stored _version is 4, _version of request is 1 (23F09)",
-      "transaction": "",
-      "typeOfError": "Multi-Status",
-      "typeOfRecord": "INSTANCE"
+      "message": "ERROR: Cannot update record c352fe11-51e2-4e8b-87d6-578d6dedec8b because it has been changed (optimistic locking): Stored _version is 4, _version of request is 1 (23F09)"
     }
   }
 ]`;
 
-const errorsData = JSON.parse(errorsString);
+const errorFromLabel = `[
+  {
+    "error": {
+      "label": "Error encountered during upsert of Inventory record set"
+    }
+  }
+]`;
 
-test('summarizes simple error', () => {
+
+test('summarizes simple error from message', () => {
+  const errorsData = JSON.parse(errorFromMessage);
   expect(errors2string(errorsData)).toBe('ERROR: Cannot update record c352fe11-51e2-4e8b-87d6-578d6dedec8b because it has been changed (optimistic locking): Stored _version is 4, _version of request is 1 (23F09)');
+});
+
+test('summarizes simple error from label', () => {
+  const errorsData = JSON.parse(errorFromLabel);
+  expect(errors2string(errorsData)).toBe('Error encountered during upsert of Inventory record set');
 });

--- a/src/util/summarizeErrors.test.js
+++ b/src/util/summarizeErrors.test.js
@@ -1,0 +1,101 @@
+import { errors2string } from './summarizeErrors';
+
+const errorsString = `[
+  {
+    "error": {
+      "label": "Error encountered during upsert of Inventory record set",
+      "entity": {
+        "id": "c352fe11-51e2-4e8b-87d6-578d6dedec8b",
+        "hrid": "1877906867",
+        "notes": [
+          {
+            "note": "Dissertation, Universität Bremen, 2023",
+            "instanceNoteTypeId": "b73cc9c2-c9fa-49aa-964f-5ae1aa754ecd"
+          }
+        ],
+        "title": "Antje test alter titel mit 3 Exemplaren. 19F-MR basierte Temperaturbestimmung in biokompatiblen Lösungen unter Einsatz neuer fluorierter Ligandensysteme und ausgewählter Übergangsmetallkomplexe / Felix Mysegaes",
+        "series": [
+          {
+            "value": "Medizinische Chemie"
+          }
+        ],
+        "source": "K10plus",
+        "_version": 1,
+        "editions": [
+          "1. Auflage"
+        ],
+        "languages": [
+          "ger"
+        ],
+        "indexTitle": "Antje test alter titel mit 3 Exemplaren 19FMR basierte Temperaturbestimmung in biokompatiblen Lösungen unter Einsatz neuer fluorierter Ligandensysteme und ausgewählter Übergangsmetallkomplexe Felix Mysegaes",
+        "identifiers": [
+          {
+            "value": "1877906867",
+            "identifierTypeId": "1d5cb40c-508f-451b-8952-87c92be4255a"
+          },
+          {
+            "value": "9783843954136",
+            "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+          },
+          {
+            "value": "KXP: 1877906867",
+            "identifierTypeId": "8e33c1be-e2c4-43ac-a975-8fb50f71137a"
+          }
+        ],
+        "publication": [
+          {
+            "role": "Publisher",
+            "place": "München",
+            "publisher": "Verlag Dr. Hut",
+            "dateOfPublication": "2024"
+          }
+        ],
+        "contributors": [
+          {
+            "name": "Mysegaes, Felix",
+            "primary": "true",
+            "contributorTypeId": "6e09d47d-95e2-4d8a-831b-f777b8ef6d81",
+            "contributorTypeText": "VerfasserIn",
+            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+          },
+          {
+            "name": "Montforts, F.-P.",
+            "contributorTypeId": "825a7d9f-7596-4007-9684-9bee72625cfc",
+            "contributorTypeText": "AkademischeR BetreuerIn",
+            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+          },
+          {
+            "name": "Plaumann, M.",
+            "contributorTypeId": "825a7d9f-7596-4007-9684-9bee72625cfc",
+            "contributorTypeText": "AkademischeR BetreuerIn",
+            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+          }
+        ],
+        "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+        "electronicAccess": [],
+        "modeOfIssuanceId": "9d18a02f-5897-4c31-9106-c9abb5c7ae8b",
+        "alternativeTitles": [],
+        "instanceFormatIds": [
+          "8d511d33-5e85-4c5d-9bce-6e3c9cd0c324"
+        ],
+        "administrativeNotes": [
+          "Aau (0500: Bibliografische Gattung)",
+          "14.01.24, 19:02 (0210: Datum der letzten Änderung)"
+        ],
+        "natureOfContentTermIds": [
+          "94f6d06a-61e0-47c1-bbcb-6186989e6040"
+        ]
+      },
+      "message": "ERROR: Cannot update record c352fe11-51e2-4e8b-87d6-578d6dedec8b because it has been changed (optimistic locking): Stored _version is 4, _version of request is 1 (23F09)",
+      "transaction": "",
+      "typeOfError": "Multi-Status",
+      "typeOfRecord": "INSTANCE"
+    }
+  }
+]`;
+
+const errorsData = JSON.parse(errorsString);
+
+test('summarizes simple error', () => {
+  expect(errors2string(errorsData)).toBe('Error encountered during upsert of Inventory record set');
+});

--- a/src/util/summarizeErrors.test.js
+++ b/src/util/summarizeErrors.test.js
@@ -97,5 +97,5 @@ const errorsString = `[
 const errorsData = JSON.parse(errorsString);
 
 test('summarizes simple error', () => {
-  expect(errors2string(errorsData)).toBe('Error encountered during upsert of Inventory record set');
+  expect(errors2string(errorsData)).toBe('ERROR: Cannot update record c352fe11-51e2-4e8b-87d6-578d6dedec8b because it has been changed (optimistic locking): Stored _version is 4, _version of request is 1 (23F09)');
 });


### PR DESCRIPTION
When a error structure has a `message` as well as a `label`, use the former rather than the latter. We still fall back to the label when there is no message.

Add tests for both cases.

These are in fact the first tests in the module, so now for the first time it's possible to run `yarn test`. A little bit of infrastructure was added to support the use of Jest.

Fixes UIHAADM-125.