### PR TITLE
Send full datetime values as part of query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Failed-record error messages should use detailed "message", when present, instead of label. Fixes UIHAADM-125.
 * Verify that stats-message parsing works for new format, add test suite. Fixes UIHAADM-124.
+* When sending end-range dates as part of a query, extend them to the datetimes at the end of the day. Fixes UIHAADM-126.
 
 ## [2.1.0](https://github.com/folio-org/ui-harvester-admin/tree/v2.1.0) (2024-02-28)
 

--- a/src/search/queryFunction.js
+++ b/src/search/queryFunction.js
@@ -5,14 +5,21 @@ const sortMap = {
   // so no mapping is required.
 };
 
-function parseFilterValue(field, op, value) {
-  return `${field}${op}${value}`;
+function parseFilterValue(field, op, value, appendToTerm) {
+  let res = `${field}${op}${value}`;
+  if (appendToTerm === undefined) {
+    return res;
+  } else {
+    return res + appendToTerm;
+  }
 }
 
-function makePFV(field, op) {
-  return (value) => parseFilterValue(field, op, value);
+function makePFV(field, op, appendToTerm) {
+  return (value) => parseFilterValue(field, op, value, appendToTerm);
 }
 
+const startOfDay = 'T00:00:00';
+const endOfDay = 'T23:59:59';
 const filterConfig = [{
   name: 'status',
   cql: 'status',
@@ -25,32 +32,32 @@ const filterConfig = [{
   name: 'started_from',
   cql: 'started_from',
   values: [],
-  parse: makePFV('started', '>='),
+  parse: makePFV('started', '>=', startOfDay),
 }, {
   name: 'started_to',
   cql: 'started_to',
   values: [],
-  parse: makePFV('started', '<='),
+  parse: makePFV('started', '<=', endOfDay),
 }, {
   name: 'finished_from',
   cql: 'finished_from',
   values: [],
-  parse: makePFV('finished', '>='),
+  parse: makePFV('finished', '>=', startOfDay),
 }, {
   name: 'finished_to',
   cql: 'finished_to',
   values: [],
-  parse: makePFV('finished', '<='),
+  parse: makePFV('finished', '<=', endOfDay),
 }, {
   name: 'timeStamp_from',
   cql: 'timeStamp_from',
   values: [],
-  parse: makePFV('timeStamp', '>='),
+  parse: makePFV('timeStamp', '>=', startOfDay),
 }, {
   name: 'timeStamp_to',
   cql: 'timeStamp_to',
   values: [],
-  parse: makePFV('timeStamp', '<='),
+  parse: makePFV('timeStamp', '<=', endOfDay),
 }, {
   name: 'records_from',
   cql: 'records_from',


### PR DESCRIPTION
When sending dates as part of a query, they are now extended to complete datetimes. Start-of-range dates are extended to the beginning of the specified day (`T00:00:00`) and end-of-range dates to the end of the specified day (`T23:59:59`).

This means that the ends of date-ranges now include the whole of the specified day rather than only its first second.

Fixes UIHAADM-126.